### PR TITLE
refactored how rel pos enc is computed

### DIFF
--- a/module/attention.py
+++ b/module/attention.py
@@ -17,24 +17,20 @@ class MultiheadAttentionRelative(nn.MultiheadAttention):
                                                          add_bias_kv=False, add_zero_attn=False,
                                                          kdim=None, vdim=None)
 
-    def gather_attn(self, indexes, bsz, dim, attn):
+    def forward(self, query, key, value, attn_mask=None, pos_enc=None, pos_indexes=None):
         """
-        indexes [LxL]: indexes to shift attn
-        attn q k_r [N,L,2L-1]: gather along dimension -1
-            L: target len
-            N: batch size
-        attn q_r k [N,2L-1,L]: gather along dimension -2
-            L: target len
-            N: batch size
+        Multihead attention
+
+        :param query: [W,HN,C]
+        :param key: [W,HN,C]
+        :param value: [W,HN,C]
+        :param attn_mask: mask to invalidate attention, -inf is used for invalid attention, [W,W]
+        :param pos_enc: [2W-1,C]
+        :param pos_indexes: index to select relative encodings, flattened in transformer WW
+        :return: output value vector, attention with softmax (for debugging) and raw attention (used for last layer)
         """
 
-        indexes = indexes.unsqueeze(0).expand([bsz, -1, -1])  # N x L x L
-        attn = torch.gather(attn, dim, indexes)
-
-        return attn
-
-    def forward(self, query, key, value, need_weights=True, attn_mask=None, pos_enc=None, pos_indexes=None):
-        tgt_len, bsz, embed_dim = query.size()
+        w, bsz, embed_dim = query.size()
         head_dim = embed_dim // self.num_heads
         assert head_dim * self.num_heads == embed_dim, "embed_dim must be divisible by num_heads"
 
@@ -68,14 +64,15 @@ class MultiheadAttentionRelative(nn.MultiheadAttention):
 
         # project to find q_r, k_r
         if pos_enc is not None:
+            # reshape pos_enc
+            pos_enc = torch.index_select(pos_enc, 0, pos_indexes).view(w, w,
+                                                                       -1)  # 2W-1xC -> WW'xC -> WxW'xC
             # compute k_r, q_r
             _start = 0
             _end = 2 * embed_dim
             _w = self.in_proj_weight[_start:_end, :]
             _b = self.in_proj_bias[_start:_end]
-            q_r, k_r = F.linear(pos_enc, _w, _b).chunk(2, dim=-1)  # 2L-1xNxE
-            if bsz == 2 * q_r.size(1):  # this is when left/right features are cat together
-                q_r, k_r = torch.cat([q_r, q_r], dim=1), torch.cat([k_r, k_r], dim=1)
+            q_r, k_r = F.linear(pos_enc, _w, _b).chunk(2, dim=-1)  # WxW'xC
         else:
             q_r = None
             k_r = None
@@ -86,73 +83,55 @@ class MultiheadAttentionRelative(nn.MultiheadAttention):
         if q_r is not None:
             q_r = q_r * scaling
 
-        # adjust attn mask size
-        if attn_mask is not None:
-            if attn_mask.dim() == 2:
-                attn_mask = attn_mask.unsqueeze(0)
-                if list(attn_mask.size()) != [1, query.size(0), key.size(0)]:
-                    raise RuntimeError('The size of the 2D attn_mask is not correct.')
-            elif attn_mask.dim() == 3:
-                if list(attn_mask.size()) != [bsz * self.num_heads, query.size(0), key.size(0)]:
-                    raise RuntimeError('The size of the 3D attn_mask is not correct.')
-            else:
-                raise RuntimeError("attn_mask's dimension {} is not supported".format(attn_mask.dim()))
-            # attn_mask's dim is 3 now.
-
         # reshape
-        q = q.contiguous().view(tgt_len, bsz * self.num_heads, head_dim).transpose(0, 1)  # N*n_head x L x E
+        q = q.contiguous().view(w, bsz, self.num_heads, head_dim)  # WxNxExC
         if k is not None:
-            k = k.contiguous().view(-1, bsz * self.num_heads, head_dim).transpose(0, 1)
+            k = k.contiguous().view(-1, bsz, self.num_heads, head_dim)
         if v is not None:
-            v = v.contiguous().view(-1, bsz * self.num_heads, head_dim).transpose(0, 1)
+            v = v.contiguous().view(-1, bsz, self.num_heads, head_dim)
 
-        if q_r is not None:  # N*n_head x 2L-1 x E
-            q_r = q_r.contiguous().view(2 * tgt_len - 1, bsz * self.num_heads, head_dim).transpose(0, 1)
+        if q_r is not None:
+            q_r = q_r.contiguous().view(w, w, self.num_heads, head_dim)  # WxW'xExC
         if k_r is not None:
-            k_r = k_r.contiguous().view(2 * tgt_len - 1, bsz * self.num_heads, head_dim).transpose(0, 1)
-
-        src_len = k.size(1)
+            k_r = k_r.contiguous().view(w, w, self.num_heads, head_dim)
 
         # compute attn weight
-        attn_feat = torch.bmm(q, k.transpose(1, 2))  # N*n_head x L x L
+        attn_feat = torch.einsum('wnec,vnec->newv', q, k)  # NxExWxW'
 
         # add positional terms
         if pos_enc is not None:
             # 0.3 s
-            attn_feat_pos = torch.einsum('ijk,ilk->ijl', q, k_r)  # N*n_head x L x 2L -1
-            attn_feat_pos = self.gather_attn(pos_indexes, bsz * self.num_heads, -1, attn_feat_pos)
-            attn_pos_feat = torch.einsum('ijk,ilk->ijl', q_r, k)  # N*n_head x 2L -1 x L
-            attn_pos_feat = self.gather_attn(pos_indexes, bsz * self.num_heads, -2, attn_pos_feat)
+            attn_feat_pos = torch.einsum('wnec,wvec->newv', q, k_r)  # NxExWxW'
+            attn_pos_feat = torch.einsum('vnec,wvec->newv', k, q_r)  # NxExWxW'
 
             # 0.1 s
-            attn_output_weights = attn_feat + attn_feat_pos + attn_pos_feat
+            attn = attn_feat + attn_feat_pos + attn_pos_feat
         else:
-            attn_output_weights = attn_feat
+            attn = attn_feat
 
-        assert list(attn_output_weights.size()) == [bsz * self.num_heads, tgt_len, src_len]
+        assert list(attn.size()) == [bsz, self.num_heads, w, w]
 
         # apply attn mask
         if attn_mask is not None:
-            attn_output_weights += attn_mask
+            attn_mask = attn_mask[None, None, ...]
+            attn += attn_mask
 
         # raw attn
-        raw_attn_output_weights = attn_output_weights
+        raw_attn = attn
 
         # softmax
-        attn_output_weights = F.softmax(attn_output_weights, dim=-1)
+        attn = F.softmax(attn, dim=-1)
 
         # compute v
-        attn_output = torch.bmm(attn_output_weights, v)
-        assert list(attn_output.size()) == [bsz * self.num_heads, tgt_len, head_dim]
-        attn_output = attn_output.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
-        attn_output = F.linear(attn_output, self.out_proj.weight, self.out_proj.bias)
+        v_o = torch.einsum('newv,vnec->wnec', attn, v)
+        assert list(v_o.size()) == [w, bsz, self.num_heads, head_dim]
+        v_o = v_o.contiguous().view(w, bsz, embed_dim)
+        v_o = F.linear(v_o, self.out_proj.weight, self.out_proj.bias)
 
         # average attention weights over heads
-        attn_output_weights = attn_output_weights.view(bsz, self.num_heads, tgt_len, src_len)
-        attn_output_weights = attn_output_weights.sum(dim=1) / self.num_heads
+        attn = attn.sum(dim=1) / self.num_heads
 
         # raw attn
-        raw_attn_output_weights = raw_attn_output_weights.view(bsz, self.num_heads, tgt_len, src_len)
-        raw_attn_output_weights = raw_attn_output_weights.sum(dim=1)
+        raw_attn = raw_attn.sum(dim=1)
 
-        return attn_output, attn_output_weights, raw_attn_output_weights
+        return v_o, attn, raw_attn

--- a/module/pos_encoder.py
+++ b/module/pos_encoder.py
@@ -42,7 +42,7 @@ class PositionEncodingSine1DRelative(nn.Module):
             _, h = inputs.sampled_rows.size()
 
         # populate all possible relative distances
-        x_embed = torch.linspace(w - 1, -w + 1, 2 * w - 1, dtype=torch.float32, device=x.device).expand(bs, h, -1)
+        x_embed = torch.linspace(w - 1, -w + 1, 2 * w - 1, dtype=torch.float32, device=x.device)
 
         # scale distance if there is down sample
         if inputs.sampled_cols is not None:
@@ -55,10 +55,9 @@ class PositionEncodingSine1DRelative(nn.Module):
         dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=x.device)
         dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)
 
-        pos_x = x_embed[:, :, :, None] / dim_t
+        pos_x = x_embed[:, None] / dim_t  # 2W-1xC
         # interleave cos and sin instead of concatenate
-        pos = torch.stack((pos_x[:, :, :, 0::2].sin(), pos_x[:, :, :, 1::2].cos()), dim=4).flatten(3)  # NxHxWxC
-        pos = pos.permute(0, 3, 1, 2)  # NxCxHx(2W-1)
+        pos = torch.stack((pos_x[:, 0::2].sin(), pos_x[:, 1::2].cos()), dim=2).flatten(1)  # 2W-1xC
 
         return pos
 

--- a/module/transformer.py
+++ b/module/transformer.py
@@ -95,13 +95,11 @@ class Transformer(nn.Module):
         feat_left = feat_left.permute(1, 3, 2, 0).flatten(2).permute(1, 2, 0)  # CxWxHxN -> CxWxHN -> WxHNxC
         feat_right = feat_right.permute(1, 3, 2, 0).flatten(2).permute(1, 2, 0)
         if pos_enc is not None:
-            pos_enc = pos_enc.permute(1, 3, 2, 0).flatten(2).permute(1, 2, 0)  # Cx2W-1xHxN -> Cx2W-1xHN -> 2W-1xHNxC
-
             with torch.no_grad():
                 # indexes to shift rel pos encoding
                 indexes_r = torch.linspace(w - 1, 0, w).view(w, 1).to(feat_left.device)
                 indexes_c = torch.linspace(0, w - 1, w).view(1, w).to(feat_left.device)
-                pos_indexes = (indexes_r + indexes_c).long()  # WxW
+                pos_indexes = (indexes_r + indexes_c).view(-1).long()  # WxW' -> WW'
         else:
             pos_indexes = None
 


### PR DESCRIPTION
Major changes:
- positional attention is now computed as matrix product of two matrix of `NxWx1xC` and `NxWxWxC`, which outputs `NxWxW` directly. Previsouly, it was computed as `NxWxC` and `Nx2W-1xC`, which outputs `NxWx2W-1` and then slicing is performed to reduce to `NxWxW`.

Minor changes:
- `pos_encoder.py` now generates a positional encoding tensor of size `2W-1xC` instead of `NxHx2W-1xC`
- `transformer.py` now generates indexes (to slice relative positional encoding) with size `WxW` instead of `NxHxWxW`
- additional documentation and variable renaming in `attention.py` module

Result:
- No performance change since this is only code improvement
- Overall, memory saving is around 1.3GB.